### PR TITLE
Build 4.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+*.DS_Store
+build_artifacts

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   skip: true  # [py<38]
   skip: true  # [linux and (aarch64 or s390x)]
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:
@@ -38,6 +38,7 @@ test:
 
 about:
   home: https://trypyramid.com
+  description: pyramid_debugtoolbar provides a debug toolbar useful while you're developing your Pyramid application.
   license: LicenseRef-Pylons
   license_family: BSD
   license_file: LICENSE.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   skip: true  # [py<38]
+  skip: true  # [linux and (aarch64 or s390x)]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "pyramid_debugtoolbar" %}
+{% set version = "4.10" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: cfc8cfaf342609577fbb93e899fbb2290b31e3418c4b68f0dae37cb3b60fe88b
+
+build:
+  skip: true  # [py<38]
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+    - wheel
+  run:
+    - python
+    - pyramid >=1.4
+    - pyramid_mako >=0.3.1
+    - repoze.lru
+    - pygments
+
+test:
+  requires:
+    - pip
+  imports:
+    - pyramid_debugtoolbar
+  commands:
+    - pip check
+
+about:
+  home: https://trypyramid.com
+  license: LicenseRef-Pylons
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: The Pyramid Web Framework, a Pylons project
+  doc_url: https://docs.pylonsproject.org/projects/pyramid_mako/en/latest/
+  dev_url: https://github.com/Pylons/pyramid_mako
+
+extra:
+  recipe-maintainers:
+    - ChrisBarker-NOAA
+    - JamesMakela-NOAA

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - python
     - pyramid >=1.4
     - pyramid_mako >=0.3.1
-    - repoze.lru
     - pygments
 
 test:


### PR DESCRIPTION
This recipe used to be an "orphaned" feedstock living in a directory under aggregate. See diff here:
 https://github.com/AnacondaRecipes/aggregate/commit/825e751507cb9c87a9958a484d1ea12d691ea497

